### PR TITLE
Fix fares imputation row[DUTY_FREE_VARIABLE] != np.nan:

### DIFF
--- a/ips/services/calculations/calculate_fares_imputation.py
+++ b/ips/services/calculations/calculate_fares_imputation.py
@@ -220,7 +220,7 @@ def compute_additional_spend(row):
         else:
             row[SPEND_VARIABLE] = (row[EXPENDITURE_VARIABLE] + row[BEFAF_VARIABLE]) / row[PERSONS_VARIABLE]
 
-    if row[SPEND_VARIABLE] != np.nan:
+    if row[SPEND_VARIABLE] != np.nan and row[DUTY_FREE_VARIABLE] != np.nan:
         row[SPEND_VARIABLE] = row[SPEND_VARIABLE] + row[DUTY_FREE_VARIABLE]
 
     # Ensure the spend values are integers


### PR DESCRIPTION
Odd that this shows up now as it works via the test. Stil it should check it's not None before adding. Quite a few other places in the code that may not survive data from other months.